### PR TITLE
Fix harvest autotask

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@nomiclabs/hardhat-ethers": "^2.1.0",
     "@nomiclabs/hardhat-etherscan": "^3.1.0",
     "@rollup/plugin-commonjs": "^22.0.2",
+    "@rollup/plugin-json": "^4.1.0",
     "@typechain/ethers-v5": "^10.1.0",
     "@typechain/hardhat": "^6.1.2",
     "chai": "^4.3.6",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@nomiclabs/hardhat-etherscan": "^3.1.0",
     "@rollup/plugin-commonjs": "^22.0.2",
     "@rollup/plugin-json": "^4.1.0",
+    "@rollup/plugin-node-resolve": "^13.3.0",
     "@typechain/ethers-v5": "^10.1.0",
     "@typechain/hardhat": "^6.1.2",
     "chai": "^4.3.6",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
   },
   "dependencies": {
     "@datadog/datadog-api-client": "^1.0.0-beta.5",
-    "@gnosis.pm/safe-core-sdk": "^0.3.1",
+    "@gnosis.pm/safe-core-sdk": "^2.3.2",
     "@gnosis.pm/safe-ethers-adapters": "^0.1.0-alpha.3",
+    "@gnosis.pm/safe-ethers-lib": "^1.4.0",
     "axios": "0.21.2",
     "axios-retry": "3.1.9",
     "defender-admin-client": "1.25.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,7 @@
 import { readdirSync } from "fs";
 import path from "path";
 import commonjs from "@rollup/plugin-commonjs";
+import json from "@rollup/plugin-json";
 
 const autotaskSrcDir = path.join("src", "autotasks");
 const autotaskInputDirs = readdirSync(autotaskSrcDir, {
@@ -27,7 +28,7 @@ const configs = autotaskInputs.map((autotaskInput) => {
       format: "cjs",
       exports: "default",
     },
-    plugins: [commonjs()],
+    plugins: [commonjs(), json()],
     external: [
       "ethers",
       "defender-relay-client/lib/ethers",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,6 +2,7 @@ import { readdirSync } from "fs";
 import path from "path";
 import commonjs from "@rollup/plugin-commonjs";
 import json from "@rollup/plugin-json";
+import { nodeResolve } from "@rollup/plugin-node-resolve";
 
 const autotaskSrcDir = path.join("src", "autotasks");
 const autotaskInputDirs = readdirSync(autotaskSrcDir, {
@@ -28,11 +29,10 @@ const configs = autotaskInputs.map((autotaskInput) => {
       format: "cjs",
       exports: "default",
     },
-    plugins: [commonjs(), json()],
+    plugins: [commonjs(), json(), nodeResolve({ preferBuiltins: true })],
     external: [
       "ethers",
       "defender-relay-client/lib/ethers",
-      "@gnosis.pm/safe-core-sdk",
       "dotenv",
       "axios",
       "axios-retry",

--- a/src/common/safe.js
+++ b/src/common/safe.js
@@ -12,6 +12,9 @@ exports.getSafe = async (signer) => {
 
 exports.executeSafeTx = async (tx, safe) => {
   const safeTx = await safe.createTransaction(tx);
+
+  // Should not be necessary per SDK docs, however the tx fails without it
+  const signedSafeTx = await safe.signTransaction(safeTx);
   const baseGas = 100000;
 
   const options = {
@@ -22,7 +25,7 @@ exports.executeSafeTx = async (tx, safe) => {
     gasLimit: safeTx.data["safeTxGas"] + baseGas,
   };
 
-  const executedTx = await safe.executeTransaction(safeTx, options);
+  const executedTx = await safe.executeTransaction(signedSafeTx, options);
 
   // Cannot use `?.` operator here because the autotask env uses node 12
   // - Optional chaining with `.?` requires node 14

--- a/src/common/safe.js
+++ b/src/common/safe.js
@@ -1,5 +1,6 @@
-const { default: Safe, EthersAdapter } = require("@gnosis.pm/safe-core-sdk");
 const { ethers } = require("ethers");
+const { default: Safe } = require("@gnosis.pm/safe-core-sdk");
+const { default: EthersAdapter } = require("@gnosis.pm/safe-ethers-lib");
 const { LP_SAFE_ADDRESS } = require("./constants");
 
 exports.getSafe = async (signer) => {

--- a/src/common/safe.js
+++ b/src/common/safe.js
@@ -1,4 +1,5 @@
 const { default: Safe, EthersAdapter } = require("@gnosis.pm/safe-core-sdk");
+const { ethers } = require("ethers");
 const { LP_SAFE_ADDRESS } = require("./constants");
 
 exports.getSafe = async (signer) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -684,7 +684,14 @@
     magic-string "^0.25.7"
     resolve "^1.17.0"
 
-"@rollup/pluginutils@^3.1.0":
+"@rollup/plugin-json@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-json/-/plugin-json-4.1.0.tgz#54e09867ae6963c593844d8bd7a9c718294496f3"
+  integrity sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==
+  dependencies:
+    "@rollup/pluginutils" "^3.0.8"
+
+"@rollup/pluginutils@^3.0.8", "@rollup/pluginutils@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
   integrity sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -494,11 +494,6 @@
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/strings" "^5.6.1"
 
-"@gnosis.pm/safe-core-sdk-types@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-core-sdk-types/-/safe-core-sdk-types-0.1.1.tgz#908c394cb4660493b4e9c8e01b5a7aa36efafd30"
-  integrity sha512-PghXGDaI5Foq37nZGmI90U2OKMeGtxh5KqkDqou9aFHwGVa/nf9HRQPxG9/XUzcyfe9OlKttDlJnR3XnC3dSDw==
-
 "@gnosis.pm/safe-core-sdk-types@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-core-sdk-types/-/safe-core-sdk-types-1.1.0.tgz#dce372445ddbaf7eb960cfe98f5d4b2557004040"
@@ -509,13 +504,24 @@
     "@gnosis.pm/safe-deployments" "^1.12.0"
     web3-core "^1.7.1"
 
-"@gnosis.pm/safe-core-sdk@^0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-core-sdk/-/safe-core-sdk-0.3.1.tgz#15171657490a90ac3773b6965c2af4b873af136f"
-  integrity sha512-L0na+KSAnicO4B9MtzPu90kwThZ2PHd11CHSRzhJ7l4oIOGB4a/KyPohcOzXTO9Vz3yDIELPlbcW5IEasUk6ag==
+"@gnosis.pm/safe-core-sdk-types@^1.2.1", "@gnosis.pm/safe-core-sdk-types@^1.3.0", "@gnosis.pm/safe-core-sdk-types@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-core-sdk-types/-/safe-core-sdk-types-1.4.0.tgz#c6615333177765b58f03cd77e165d4d36b9d2c91"
+  integrity sha512-v+V6wqfFVgBl2sZ8FqCMwL/qFnr6wBCcJ/gllo4OvItYw/dmXlMCkxUrERoILSeHDezLkrWnnzA4tHfkEwYuwg==
   dependencies:
-    "@gnosis.pm/safe-core-sdk-types" "^0.1.1"
-    ethereumjs-util "^7.0.10"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/contracts" "^5.6.0"
+    "@gnosis.pm/safe-deployments" "1.15.0"
+    web3-core "^1.7.1"
+
+"@gnosis.pm/safe-core-sdk-utils@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-core-sdk-utils/-/safe-core-sdk-utils-1.2.1.tgz#1cc9de8187e724c02104a8c15c14fb77796d1240"
+  integrity sha512-VPnSLayGR4omwcNHPwzx8/aDyGXrWULKSF+ENeiWbmwgIhwQnB7T2gzhArNeUgt4BxmYft/HFm1MRSqiQnIQJw==
+  dependencies:
+    "@gnosis.pm/safe-core-sdk-types" "^1.2.1"
+    semver "^7.3.7"
+    web3-utils "^1.7.1"
 
 "@gnosis.pm/safe-core-sdk@^2.1.0":
   version "2.1.0"
@@ -528,6 +534,25 @@
     ethereumjs-util "^7.1.4"
     semver "^7.3.5"
     web3-utils "^1.7.1"
+
+"@gnosis.pm/safe-core-sdk@^2.3.2":
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-core-sdk/-/safe-core-sdk-2.3.2.tgz#6b955ac8b9f748144ba54a200c12f3439af6c3b6"
+  integrity sha512-XD50+AU7ahHwX0+YG8jeyqxrqNsEdLfCzAS5+9WkGuXMNm+K4jkJ9yBHN5yKAu5JXeCDYEQkjTSdVilm8ZLpXQ==
+  dependencies:
+    "@ethersproject/solidity" "^5.6.0"
+    "@gnosis.pm/safe-core-sdk-types" "^1.3.0"
+    "@gnosis.pm/safe-deployments" "1.15.0"
+    ethereumjs-util "^7.1.4"
+    semver "^7.3.5"
+    web3-utils "^1.7.1"
+
+"@gnosis.pm/safe-deployments@1.15.0":
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-deployments/-/safe-deployments-1.15.0.tgz#71ed9a37437a3080443c49aa65308f2d8839d751"
+  integrity sha512-twfC5HNuj+TKS2gOowf6A1FGZfOLBHAV2JhYpmOCf2MKsfcG+Fe4TrSRgQg605MhWdwFiaGVpNkcwjvpxhGuew==
+  dependencies:
+    semver "^7.3.7"
 
 "@gnosis.pm/safe-deployments@^1.12.0":
   version "1.14.0"
@@ -543,6 +568,14 @@
     "@gnosis.pm/safe-core-sdk-types" "^1.1.0"
     "@gnosis.pm/safe-deployments" "^1.12.0"
     axios "^0.26.1"
+
+"@gnosis.pm/safe-ethers-lib@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-ethers-lib/-/safe-ethers-lib-1.4.0.tgz#5d884c8c083c811f753a2602fba3decf73b3a5f9"
+  integrity sha512-ImKNocwoJB19g9nEcorLG1FuYQZyK+llcCIShSw0R7f3OHi30gjcQJek/rJv+wKetM66s7Dz26xtb2X9ARN3Gg==
+  dependencies:
+    "@gnosis.pm/safe-core-sdk-types" "^1.4.0"
+    "@gnosis.pm/safe-core-sdk-utils" "^1.2.1"
 
 "@humanwhocodes/config-array@^0.10.4":
   version "0.10.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -691,6 +691,18 @@
   dependencies:
     "@rollup/pluginutils" "^3.0.8"
 
+"@rollup/plugin-node-resolve@^13.3.0":
+  version "13.3.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.3.0.tgz#da1c5c5ce8316cef96a2f823d111c1e4e498801c"
+  integrity sha512-Lus8rbUo1eEcnS4yTFKLZrVumLPY+YayBdWXgFSHYhTT2iJbMhoaaBL3xl5NCdeRytErGr8tZ0L71BMRmnlwSw==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    "@types/resolve" "1.17.1"
+    deepmerge "^4.2.2"
+    is-builtin-module "^3.1.0"
+    is-module "^1.0.0"
+    resolve "^1.19.0"
+
 "@rollup/pluginutils@^3.0.8", "@rollup/pluginutils@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
@@ -1012,6 +1024,13 @@
   version "6.9.7"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
   integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
+
+"@types/resolve@1.17.1":
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.17.1.tgz#3afd6ad8967c77e4376c598a82ddd58f46ec45d6"
+  integrity sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==
+  dependencies:
+    "@types/node" "*"
 
 "@types/secp256k1@^4.0.1":
   version "4.0.3"
@@ -1642,6 +1661,11 @@ bufferutil@^4.0.1:
   dependencies:
     node-gyp-build "^4.3.0"
 
+builtin-modules@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.3.0.tgz#cae62812b89801e9656336e46223e030386be7b6"
+  integrity sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==
+
 bytes@3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
@@ -2169,6 +2193,11 @@ deep-is@^0.1.3, deep-is@~0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
+
+deepmerge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
+  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
 
 defender-admin-client@1.25.0:
   version "1.25.0"
@@ -4034,6 +4063,13 @@ is-buffer@~2.0.3:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
   integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
 
+is-builtin-module@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-3.2.0.tgz#bb0310dfe881f144ca83f30100ceb10cf58835e0"
+  integrity sha512-phDA4oSGt7vl1n5tJvTWooWWAsXLY+2xCnxNqvKhGEzujg+A43wPlPOyDg3C8XQHN+6k/JTQWJ/j0dQh/qr+Hw==
+  dependencies:
+    builtin-modules "^3.3.0"
+
 is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.4.tgz#47301d58dd0259407865547853df6d61fe471945"
@@ -4091,6 +4127,11 @@ is-hex-prefixed@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz#7d8d37e6ad77e5d127148913c573e082d777f554"
   integrity sha512-WvtOiug1VFrE9v1Cydwm+FnXd3+w9GaeVUss5W4v/SLy3UW00vP+6iNF2SdnfiBoLy4bTqVdkftNGTUeOFVsbA==
+
+is-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
+  integrity sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==
 
 is-negative-zero@^2.0.2:
   version "2.0.2"
@@ -5922,7 +5963,7 @@ resolve@1.17.0:
   dependencies:
     path-parse "^1.0.6"
 
-resolve@^1.1.6, resolve@^1.17.0:
+resolve@^1.1.6, resolve@^1.17.0, resolve@^1.19.0:
   version "1.22.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
   integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==


### PR DESCRIPTION
Major change is removing the external dependency on `safe-core-sdk` and instead rolling the dependency in the build.